### PR TITLE
Fixed YT Links in Guilty Pleasures (found with script)

### DIFF
--- a/hitster-de-aaaa0015.csv
+++ b/hitster-de-aaaa0015.csv
@@ -60,9 +60,9 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 59,How Will I Know (Who You Are),Jessica Folcker,1998,https://www.youtube.com/watch?v=5sJ4oxGDqzQ,cf427acab355d70a5f22c3a39a6426577dbbf1a576995033da95f640374fdeba,How Will I Know (Who You Are),NLA379800019
 60,Marvin Gaye (feat. Meghan Trainor),Charlie Puth,2015,https://youtu.be/igNVdlXhKcI?t=9,ec47491e17b2c2f81e774e154c4b45041110c52c8d3b33cce147e95d1c1fa418,Charlie Puth - Marvin Gaye ft. Meghan Trainor [Official Video],USAT21500254
 61,Hotel California,Eagles,1976,https://www.youtube.com/watch?v=BciS5krYL80,e56609d059e9372112e9803fac70b4a3273ea40bc2a635baf8db971320261349,Hotel California (2013 Remaster),USEE11300353
-62,Komm gib mir deine Hand,Tony Marshall,1971,https://www.youtube.com/watch?v=If40-PyRyxA,96a466eebb3df8b349e8eb103948c9d032d0468e20ffed456d2ceb3ac4fd71e7,Komm gib mir deine Hand,DEC717100004
+62,Komm gib mir deine Hand,Tony Marshall,1971,https://www.youtube.com/watch?v=dgAPdpqzIbw,96a466eebb3df8b349e8eb103948c9d032d0468e20ffed456d2ceb3ac4fd71e7,Komm gib mir deine Hand,DEC717100004
 63,Schickeria,Spider Murphy Gang,1981,https://www.youtube.com/watch?v=Ity1AA7pnFM,e1c216e711525ff3e8d7b8edc350769a6d89799e88645ecb04a0e1ecc852b01b,Schickeria,DEA348101052
-64,"Ja, ja, die Katja, die hat ja",Heino,1980,https://www.youtube.com/watch?v=DJnaeEZS3go,40cd4c591199ceaeb35b26b25b938ef4af3d0b4238ac88e5c51e97f84ea051d1,"Ja, ja, die Katja, die hat ja",DEA348000473
+64,"Ja, ja, die Katja, die hat ja",Heino,1980,https://www.youtube.com/watch?v=JlmSE3geH5o,40cd4c591199ceaeb35b26b25b938ef4af3d0b4238ac88e5c51e97f84ea051d1,"Ja, ja, die Katja, die hat ja",DEA348000473
 65,Als wär's das erste Mal,Unheilig,2014,https://www.youtube.com/watch?v=R5ZWrQ-MX6Q,9c92cdccffe2fae888cd27f02dc90c3f3128737df90cb969d982501233d8d2d8,Als wär's das erste Mal,DEUM71400175
 66,Amazing,INNA,2010,https://www.youtube.com/watch?v=czRYJCzGO3A,c7db88d886f20fb88f5383f3efe2479c337a6577c309eff3698d76a5fcc6f190,INNA - Amazing | Official Single (by Play & Win),ROROT0901606
 67,Bye Bye Bye,*NSYNC,2000,https://www.youtube.com/watch?v=C27NShgTQE4,e06fde0a1eb9ceda207c4c4009a71465976a36ca552c2f790b03447ac24d002b,*NSYNC - Bye Bye Bye (Official Audio),USJI10000001
@@ -87,11 +87,11 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 86,I Kissed A Girl,Katy Perry,2008,https://www.youtube.com/watch?v=usvTbqTHwyw,eac97f0d0f725db858782837b69bf4e4576f388e05d6a34c19da3d548ef2658d,I Kissed A Girl,USCA20801738
 87,Ironic,Alanis Morissette,1995,https://www.youtube.com/watch?v=Adu-EfJbuBs,8d5d2960efa5882e5e8f3d6aaec8ada8489c3eb266ec7b9fbb0c4f81501bdaa8,Ironic (2015 Remaster),USMV29400003
 88,Mercy,Shawn Mendes,2016,https://www.youtube.com/watch?v=YfuyEdCpAp0,a59a423d678baad89ae0f300ce36d28bbbf4d13947b93564b40f49989f40a55f,Mercy,USUM71603531
-89,Flying,Nice Little Penguins,1994,https://www.youtube.com/watch?v=iSqguQk55CI,dadb103ca46254b086725a0b13806600dc79cc9a95017bb86e83d38398902008,Flying,DKELA9400302
+89,Flying,Nice Little Penguins,1994,https://www.youtube.com/watch?v=l5x1gQxa1g4,dadb103ca46254b086725a0b13806600dc79cc9a95017bb86e83d38398902008,Flying,DKELA9400302
 90,It's My Party,Lesley Gore,1963,https://www.youtube.com/watch?v=RjdH_NmmO0I,ba144059bbca38d2c3103f6bd26d02a280d1a828527a11b23213a7058fc963a4,It's My Party,USPR36205231
 91,To All the Girls I've Loved Before,Julio Iglesias & Willie Nelson,1984,https://www.youtube.com/watch?v=7As9e3uLpV4,60e5daa1ced99f4ebeba49de9ce2f2a12330a7351db8aac5f03ea8cf7bb40492,Julio Iglesias - To All the Girls I've Loved Before (Official Audio),NLB630000270
 92,Dann küss mich doch,Nicole,1992,https://www.youtube.com/watch?v=STIi47fPnyI,faf1972b938650b089bad18664cc8a1b75f73ba329c59d0cbfa86175e507bd3a,Dann küss mich doch,DEC719200001
-93,Heaven Is A Place On Earth,Belinda Carlisle,1987,https://www.youtube.com/watch?v=UocN_FLb3To,3ac9bc9ba654bb55f9f13e7e55b119439146805c90bbabe3b02f963373a01635,Heaven Is a Place on Earth,GBAAA8700010
+93,Heaven Is A Place On Earth,Belinda Carlisle,1987,https://www.youtube.com/watch?v=j2F4INQFjEI,3ac9bc9ba654bb55f9f13e7e55b119439146805c90bbabe3b02f963373a01635,Heaven Is a Place on Earth,GBAAA8700010
 94,All By Myself,Eric Carmen,1975,https://www.youtube.com/watch?v=iN9CjAfo5n0,d27273d21fc428f6836439c5266e9b64e7d878c1063b46732becf84e02c15093,Eric Carmen - All by Myself (Audio),USAR10400530
 95,I Love Your Smile,Shanice,1991,https://www.youtube.com/watch?v=zokhyLQloBI,c48c12e4712ec6a3943ce89c7eaa2d87a9b9ba06741a60bac8242a0e690a906f,I Love Your Smile,USMO19190003
 96,Summer Son,Texas,1999,https://www.youtube.com/watch?v=wUfKbWyr-OM,8449eddd20c0f08fc050f0d34b441860fd90277f18759069e3ed178d69b93eda,Summer Son,GBF089900144
@@ -307,6 +307,7 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 306,How Deep Is Your Love,Bee Gees,1977,https://www.youtube.com/watch?v=o51p5IRJ5Tc,543064f144c62657d040d088cf3db7b2a5f1c447a353e3b7441db7620452a093,How Deep Is Your Love,GBAKW7701005
 307,Long Train Runnin',The Doobie Brothers,1973,https://www.youtube.com/watch?v=CVsLEI-hCXw,af70b07c0528a0becc7b37cfd513a2b84db2ab9a2362eea3c7bd119d3b4a0fe4,Long Train Runnin',USWB19900751
 308,Whistle,Flo Rida,2012,https://www.youtube.com/watch?v=mRaffkti2us,6556bf47f8e7ec8430afc4cdfcec86c211d4ecd4a4f7497484553039930ac79d,Flo Rida - Whistle [Oficial Audio HD],USAT21201745
+
 
 
 

--- a/hitster-de-aaaa0015.csv
+++ b/hitster-de-aaaa0015.csv
@@ -307,8 +307,3 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 306,How Deep Is Your Love,Bee Gees,1977,https://www.youtube.com/watch?v=o51p5IRJ5Tc,543064f144c62657d040d088cf3db7b2a5f1c447a353e3b7441db7620452a093,How Deep Is Your Love,GBAKW7701005
 307,Long Train Runnin',The Doobie Brothers,1973,https://www.youtube.com/watch?v=CVsLEI-hCXw,af70b07c0528a0becc7b37cfd513a2b84db2ab9a2362eea3c7bd119d3b4a0fe4,Long Train Runnin',USWB19900751
 308,Whistle,Flo Rida,2012,https://www.youtube.com/watch?v=mRaffkti2us,6556bf47f8e7ec8430afc4cdfcec86c211d4ecd4a4f7497484553039930ac79d,Flo Rida - Whistle [Oficial Audio HD],USAT21201745
-
-
-
-
-

--- a/hitster-de-aaaa0015.csv
+++ b/hitster-de-aaaa0015.csv
@@ -14,11 +14,11 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 13,Holiday,The Other Ones,1986,https://www.youtube.com/watch?v=PSP-S882RKc,aa9a8e2dee5a04f8781700e639f0fc4d08a89c19facdb9765f4a721007e3bb3c,Holiday,DEG128600401
 14,Hijo de la Luna,Mecano,1986,https://www.youtube.com/watch?v=sIIEP6pVACA,2e9744b874ea2111907aac31e86e3fdad91d6874436f715047a2206a8bc14a8b,Hijo de la Luna,ES5028600049
 15,I'd Do Anything For Love (But I Won't Do That),Meat Loaf,1993,https://www.youtube.com/watch?v=kOeu1QhrCZg,fb61b53d2f71a73f43ce2a9dcc8b2fed7eaff81d584780342b4397e6fc936aac,I'd Do Anything For Love (But I Won't Do That) (Single Edit),USMC19341323
-16,Soulmate,Natasha Bedingfield,2007,https://www.youtube.com/watch?v=PSmEy0CyWFs,0e32b2ae68bdb816e9c296ff429955b185c81523be556a9fa3d87cbd16e6369f,Soulmate,GBARL0700096
+16,Soulmate,Natasha Bedingfield,2007,https://www.youtube.com/watch?v=P27MPi3ZhCg,0e32b2ae68bdb816e9c296ff429955b185c81523be556a9fa3d87cbd16e6369f,Soulmate,GBARL0700096
 17,Faust auf Faust (Schimanski),Klaus Lage,1985,https://www.youtube.com/watch?v=CLF-ZCb9E5s,fcda845cc74af1ee21d971fe9b4cec55b1014d586928b12e5366b4f526182b59,Faust auf Faust (Schimanski) (Remastered 2007),DEA340700759
 18,Because I Love You,Stevie B,1990,https://www.youtube.com/watch?v=Tm4lcJ9nMSw,7691b485afa0650da143fae3c0fc0147a104e8e63790014645bfe6b8f1b137c0,Because I Love You,AUGBT2311775
 19,Anywhere,Rita Ora,2018,https://www.youtube.com/watch?v=ksdAs4LBRq8,5855cac387ce83ceae44998cf9bc89ea090bf68e240574ad7292290578457314,Rita Ora - Anywhere [Official Video],GBAHS1701111
-20,Can't Take My Eyes off You,Frankie Valli,1967,https://www.youtube.com/watch?v=iObGpqXKBdY,6621a64a0bd7c50277e98853b6706017cbdc86f6505c6758a9da8e5778116603,Cant Take My Eyes off You,USRH11000238
+20,Can't Take My Eyes off You,Frankie Valli,1967,https://www.youtube.com/watch?v=DYwQy_9JPtQ,6621a64a0bd7c50277e98853b6706017cbdc86f6505c6758a9da8e5778116603,Cant Take My Eyes off You,USRH11000238
 21,High Hopes,Panic! At The Disco,2018,https://www.youtube.com/watch?v=GJY8OMJXRAk,b279e59289c9a658d62907a89f6837adf8192f9fd4b21461b43cff94667a496b,High Hopes,USAT21801174
 22,Love Me Like You Do,Ellie Goulding,2015,https://www.youtube.com/watch?v=725WlG1idPc,1ea7601096f1e895b6ab80e4b822bf897716115b987a8031d4a05b40a0f92be2,Ellie Goulding - Love Me Like You Do (Official Audio),GBUM71406823
 23,"Sugar, Sugar",The Archies,1969,https://www.youtube.com/watch?v=Om5O6GL7cLY,b5972e082451ecb7ab32e4655b7de0f5e583c7a9790ccb41835ef4c8ae1d25bf,Sugar Sugar,NLG620400826
@@ -307,5 +307,6 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 306,How Deep Is Your Love,Bee Gees,1977,https://www.youtube.com/watch?v=o51p5IRJ5Tc,543064f144c62657d040d088cf3db7b2a5f1c447a353e3b7441db7620452a093,How Deep Is Your Love,GBAKW7701005
 307,Long Train Runnin',The Doobie Brothers,1973,https://www.youtube.com/watch?v=CVsLEI-hCXw,af70b07c0528a0becc7b37cfd513a2b84db2ab9a2362eea3c7bd119d3b4a0fe4,Long Train Runnin',USWB19900751
 308,Whistle,Flo Rida,2012,https://www.youtube.com/watch?v=mRaffkti2us,6556bf47f8e7ec8430afc4cdfcec86c211d4ecd4a4f7497484553039930ac79d,Flo Rida - Whistle [Oficial Audio HD],USAT21201745
+
 
 

--- a/hitster-de-aaaa0015.csv
+++ b/hitster-de-aaaa0015.csv
@@ -244,7 +244,7 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 243,The Power Of Love,Huey Lewis & The News,1985,https://www.youtube.com/watch?v=-UQFBtHEFJ8,aa25aa160eb4578ecfe4f36d40f54d6b607253b2e7f0b62e116dc231309cc047,The Power Of Love- Huey Lewis And The News,USCA20600519
 244,Music Is The Key,Sarah Connor,2003,https://www.youtube.com/watch?v=5EmNiiAutno,1c672f776eed930dcfff9e9b09b4991abae5aed4cbca4a6fe78541b292e388bb,Sarah Connor - Music Is The Key (Official Video) ft. Naturally 7,DEE860300940
 245,Be My Baby,The Ronettes,1963,https://www.youtube.com/watch?v=jSPpbOGnFgk,934af49bdf526af482b67da2d88b6ffc8fec598ad15cb7e11cad97ef36cd42e5,The Ronettes - Be My Baby (Official Audio),USQX91100088
-246,I'm Yours,Jason Mraz,2008,https://www.youtube.com/watch?v=J2TKTLOwjeg,307b2b36c91593f01463e74d8593d4b217877c95d62f341909d5d4a8aec4ff23,"JASON MRAZ - I'm Yours (Lyrics Video) ""Well open up your mind and see like me""",USEE10800667
+246,I'm Yours,Jason Mraz,2008,https://www.youtube.com/watch?v=EkHTsc9PU2A,307b2b36c91593f01463e74d8593d4b217877c95d62f341909d5d4a8aec4ff23,"JASON MRAZ - I'm Yours (Lyrics Video) ""Well open up your mind and see like me""",USEE10800667
 247,Magia,Alvaro Soler,2021,https://www.youtube.com/watch?v=Irwea_BVBhI,d2450ce7648a33b05d69f8310e39121c43e3cb07489511cd2c87afac059e36e6,Alvaro Soler - Magia,DEUM72100298
 248,Mrs. Robinson,Simon & Garfunkel,1968,https://www.youtube.com/watch?v=9C1BCAgu2I8,908ffb217f2c2b98d1a2f1d45d338f0a352c5786b8284848a90964af8a080ddb,Simon & Garfunkel - Mrs. Robinson (Audio),USSM16800379
 249,Forever in Love,Sylver,2001,https://www.youtube.com/watch?v=Ue2KkI3DLhU,457438a08b908ec1a118774592ef5bade2626c6678fc77933538424d7359d90f,Forever in Love,BEAA10114101
@@ -307,4 +307,5 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 306,How Deep Is Your Love,Bee Gees,1977,https://www.youtube.com/watch?v=o51p5IRJ5Tc,543064f144c62657d040d088cf3db7b2a5f1c447a353e3b7441db7620452a093,How Deep Is Your Love,GBAKW7701005
 307,Long Train Runnin',The Doobie Brothers,1973,https://www.youtube.com/watch?v=CVsLEI-hCXw,af70b07c0528a0becc7b37cfd513a2b84db2ab9a2362eea3c7bd119d3b4a0fe4,Long Train Runnin',USWB19900751
 308,Whistle,Flo Rida,2012,https://www.youtube.com/watch?v=mRaffkti2us,6556bf47f8e7ec8430afc4cdfcec86c211d4ecd4a4f7497484553039930ac79d,Flo Rida - Whistle [Oficial Audio HD],USAT21201745
+
 

--- a/hitster-de-aaaa0015.csv
+++ b/hitster-de-aaaa0015.csv
@@ -120,7 +120,7 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 119,The Joker,Steve Miller Band,1974,https://www.youtube.com/watch?v=q3mfENm6VJc,7ea81465ea1c697f8b29b7db65b9524adfcf2c6a454c3fb10319d444eddbd465,The Joker,USCA29100532
 120,(Is This The Way To) Amarillo,Tony Christie,1971,https://www.youtube.com/watch?v=kyohWo3aZvw,61cec614fd302e969042288ca60c3504b5dfbfe53ff661e6a094324bf4427f3c,[Is This The Way To] Amarillo,USMC10200219
 121,Book Of Love (feat. Polina),Felix Jaehn,2015,https://www.youtube.com/watch?v=6vyPU5ASG98,fa63ec17aab5eeaa3c15bc48e09e06c2156292628d35653beeffebe799014e62,Felix Jaehn - Book Of Love (Official Video) ft. Polina,DEUM71502573
-122,"Küss mich, Halt mich, Lieb mich (Drei Haselnüsse für Aschenbrödel)",Ella Endlich,2009,https://www.youtube.com/watch?v=QBsIDPi3kko,5eb502723ea0e48ff0ed225a695a43b449e889c39db31f617942d275a5b5c923,"Küss mich, halt mich, lieb mich",DEZ651214396
+122,"Küss mich, Halt mich, Lieb mich (Drei Haselnüsse für Aschenbrödel)",Ella Endlich,2009,https://www.youtube.com/watch?v=xzSHh4BT4Vc,5eb502723ea0e48ff0ed225a695a43b449e889c39db31f617942d275a5b5c923,"Küss mich, halt mich, lieb mich",DEZ651214396
 123,Mamma Mia,ABBA,1975,https://www.youtube.com/watch?v=U4Sm7v6PDY8,f4d3ea19b0a09383585d240e7b4ea6902544e3a634999578de3df679fa61cd4e,ABBA - Mamma Mia (Official Lyric Video),SEAYD7501010
 124,Girl on Fire,Alicia Keys,2012,https://www.youtube.com/watch?v=mVuSfxqpZa4,5f7cf835178bf30c70df8fd5ca054c6a2745c256b23109ebcf5e228df163d6ca,Girl on Fire,USRC11201015
 125,Light My Fire,The Doors,1967,https://www.youtube.com/watch?v=qoX6AKuYWL8,06c8c7fa32ab3bf7d38e9fd97d13e2ccc0d6d64e6c087f6efecfc0f0d50b60db,Light My Fire (2017 Remaster),USEE19900203
@@ -185,7 +185,7 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 184,Shut Up and Dance,WALK THE MOON,2014,https://www.youtube.com/watch?v=nbcCG7PkI18,a39830e2981666fd09ca290e07a7169e41b41c497d18cbc99503e14dd1d4e765,WALK THE MOON - Shut Up and Dance (Audio),USRC11401949
 185,Achy Breaky Heart,Billy Ray Cyrus,1992,https://www.youtube.com/watch?v=vDjbZVawd68,51f288bd7bc57c1054a0458d70d801359ebcee14903c4b453b9c6eb4fdf6e65e,Achy Breaky Heart,USPG19290113
 186,Ein Herz kann man nicht reparieren,Udo Lindenberg,1991,https://www.youtube.com/watch?v=DZgTN-yjVyg,335f716b608068572375731265c5eef14d00e7284304e480005633b5c8d803df,Ein Herz kann man nicht reparieren,DEF069015020
-187,Bleeding Love,Leona Lewis,2007,https://www.youtube.com/watch?v=CFJtRiKgLhE,c555129228970bcf68533382d1e12f085f608c4da9c5cdd78c0027d857d06312,Bleeding Love,GBHMU0700049
+187,Bleeding Love,Leona Lewis,2007,https://www.youtube.com/watch?v=7_weSk0BonM,c555129228970bcf68533382d1e12f085f608c4da9c5cdd78c0027d857d06312,Bleeding Love,GBHMU0700049
 188,Soak Up The Sun,Sheryl Crow,2002,https://youtu.be/ynTRWe3J9UM?t=15,4e12482f0eb2a2db41eedfc3c422cb156cbe034048612eb70d33daeec7bc2a7f,Soak Up The Sun,USAM10200092
 189,Mandy,Barry Manilow,1974,https://www.youtube.com/watch?v=AvGpvQbkccE,a4d6968667b9c6c2f978522d6136da0075cf432ad79ea2696f78190b1652f980,Barry Manilow - Mandy (Audio),USAR17400164
 190,Ich bin verliebt in die Liebe,Chris Roberts,1970,https://www.youtube.com/watch?v=JsRgDkWdSJk,16818a402568a46c778ada7f78937511da3662f49140d61d07bd7df31f73893c,Ich bin verliebt in die Liebe,DEF067004940
@@ -214,11 +214,11 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 213,Beautiful Day,U2,2000,https://www.youtube.com/watch?v=rIKTwELuCLw,167a5a546fcdcf3309914de4b3af399d9d1504981560eec43d5a6d28e30ae712,Beautiful Day,GBAAN0000196
 214,Summer Love,Mark Medlock,2008,https://www.youtube.com/watch?v=hxnPBeZAg30,282c19e9a77148d14223cd7f2a6e44b8c564199469711d29f2bddf4ce4cc69ad,Summer Love,DEE860800263
 215,White Flag,Dido,2003,https://www.youtube.com/watch?v=jRqhGC5vgC0,d7ec0715c08ec42e8bee8e9a1c4ff8cffc78ed3a7afa512bfe3dd6adb62d6c93,White Flag,GBBXH0300035
-216,Flames Of Love,Fancy,1988,https://www.youtube.com/watch?v=7MRWnFCmCt0,5a0941ec0a2308514f3520703189ff1e531a251d5c1c784b4061b9fd75a8c7ae,Flames Of Love,DEP551911248
+216,Flames Of Love,Fancy,1988,https://www.youtube.com/watch?v=8C35sdjc_cw,5a0941ec0a2308514f3520703189ff1e531a251d5c1c784b4061b9fd75a8c7ae,Flames Of Love,DEP551911248
 217,Like a Prayer,Madonna,1989,https://www.youtube.com/watch?v=b_rIk8yKDGI,88496c507301227fe8aeb132a6ed3128068d853cdb2b748180f41a6af7c8ebcb,Like a Prayer,USWB10002775
 218,It's My Life,DJ BoBo,1996,https://www.youtube.com/watch?v=WEQLaMXrgnQ,eb59ae81abe9107daeb64660cbb3bd621522ef606b6d538a6ec8207505d7b43e,DJ Bobo - It's My Life (Official Audio),DEMI69600004
 219,A Neverending Dream,X-Perience,1996,https://www.youtube.com/watch?v=8tvqlU4-PV4,50cebf46201741d6d9324675596ab14e293daf6a84760a259c531e7bc09f41f9,A Neverending Dream,DEA629663339
-220,I Was Made For Lovin' You,KISS,1979,https://www.youtube.com/watch?v=12fJAnaif34,01f754bfc7ef81800fda39574bf76a9b84951a45e298762db2d98c31e597c341,I Was Made For Lovin' You,USPR39330175
+220,I Was Made For Lovin' You,KISS,1979,https://www.youtube.com/watch?v=ZhIsAZO5gl0,01f754bfc7ef81800fda39574bf76a9b84951a45e298762db2d98c31e597c341,I Was Made For Lovin' You,USPR39330175
 221,Caravan Of Love,The Housemartins,1986,https://www.youtube.com/watch?v=At_ykyi1ad8,96fd00ad8a6a8bc9ee8103b5173358b43a6540b7d9f6a7d69dcd22f940894c9d,Caravan Of Love,GBF080080423
 222,Rolling in the Deep,Adele,2010,https://www.youtube.com/watch?v=bDtjO-R0QSo,ad802be667c9698770fd38661fc711edeebcb42cfdce996974d3eca0641bd88e,Adele - Rolling In The Deep,GBBKS1000335
 223,Song of Joy - Himno a la alegría,Miguel Ríos,1970,https://www.youtube.com/watch?v=WPz7efM0Es4,e03af41e3458ff198e9536e854b40d91d575a2efe9ed63e7478707efcf86f082,Miguel Ríos - Himno de la alegría (Audio Oficial),ES5151401396
@@ -307,6 +307,7 @@ Card#,Title,Artist,Year,URL,Hashed Info,Youtube-Title,ISRC
 306,How Deep Is Your Love,Bee Gees,1977,https://www.youtube.com/watch?v=o51p5IRJ5Tc,543064f144c62657d040d088cf3db7b2a5f1c447a353e3b7441db7620452a093,How Deep Is Your Love,GBAKW7701005
 307,Long Train Runnin',The Doobie Brothers,1973,https://www.youtube.com/watch?v=CVsLEI-hCXw,af70b07c0528a0becc7b37cfd513a2b84db2ab9a2362eea3c7bd119d3b4a0fe4,Long Train Runnin',USWB19900751
 308,Whistle,Flo Rida,2012,https://www.youtube.com/watch?v=mRaffkti2us,6556bf47f8e7ec8430afc4cdfcec86c211d4ecd4a4f7497484553039930ac79d,Flo Rida - Whistle [Oficial Audio HD],USAT21201745
+
 
 
 


### PR DESCRIPTION
Used the following script, feel free to adopt it, if you find it useful:

```
#!/bin/bash

if ! command -v csvcut >/dev/null 2>&1
then
    echo "csvcut could not be found, you may need to install csvkit first."
    exit 1
fi

if ! command -v yt-dlp >/dev/null 2>&1
then
    echo "yt-dlp could not be found, you may need to install it first."
    exit 1
fi

if [  $# -lt 1 ]; then 
    echo "Usage: ./check-links.sh filename.csv. Expects the youtube links at the 5th column."
    exit 1
fi

echo "Checking youtube links for errors. This takes a few seconds per video. Warnings can be ignored. Prints the youtube ids of each video."


csvcut -x -c 5 -K 1 "$1" | xargs -L1 yt-dlp -s -q
# Explanation:
# csvcut cuts the 5th column from the given csv file, remove the first row, omit empty lines
# See https://csvkit.readthedocs.io/en/latest/common_arguments.html
# passes the urls to yt-dlp 
# -s do not download video from youtube
# -q show only warnings and errors
# https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#usage-and-options
#
```